### PR TITLE
chore - improve Problem2 with Bron-Kerbosh

### DIFF
--- a/src/main/scala/dev/gaston/schabas/take/home/zyzygy/problem2/Problem2Solution.scala
+++ b/src/main/scala/dev/gaston/schabas/take/home/zyzygy/problem2/Problem2Solution.scala
@@ -7,88 +7,123 @@ object Problem2Solution:
     def withSortedCodes: PromotionCombo = copy(promotionCodes = promotionCodes.sorted)
 
   /**
-   * @param allPromotions all available promotions
-   * @return all PromotionCombos with maximum number of combinable promotions in each.
+   * Compute all maximal combinable promotion sets.
+   *
+   * Pipeline:
+   *   - Canonicalize input by merging duplicate codes and symmetrizing incompatibilities (via promotion map).
+   *   - Build the compatibility graph (undirected).
+   *   - Use Bron–Kerbosch with pivoting to enumerate maximal cliques (each clique is a combinable set).
+   *
+   * Notes:
+   *   - Returns empty when no promotions are provided.
+   *   - Result order is not guaranteed; sort externally for deterministic comparisons.
+   *   - Codes inside PromotionCombo are returned as provided; tests may sort via `withSortedCodes`.
+   *
+   * @param allPromotions all available promotions (duplicates by code are allowed)
+   * @return all PromotionCombos with maximum number of combinable promotions in each (order not guaranteed)
    */
   def allCombinablePromotions(allPromotions: Seq[Promotion]): Seq[PromotionCombo] =
-    val allValidCombos = generateAllValidCombinations(allPromotions)
-    findMaximalCombinations(allValidCombos, allPromotions)
+    val promotionMap = buildPromotionMap(allPromotions)
+    if promotionMap.isEmpty then Seq.empty
+    else
+      val compatibilityGraph = buildCompatibilityGraph(promotionMap)
+      val cliques = bronKerboschPivot(Set.empty, compatibilityGraph.keySet, Set.empty, compatibilityGraph)
+      cliques
+        .filter(_.nonEmpty)
+        .map(c => PromotionCombo(c.toSeq))
+        .toSeq
 
   /**
-   * @param promotionCode the code of the promotion
-   * @param allPromotions all available promotions
-   * @return all PromotionCombos for a given Promotion from given list of Promotions.
+   * Compute all maximal combinable promotion sets that include a given promotion code.
+   *
+   * Implementation seeds Bron–Kerbosch with R={promotionCode}, P=neighbors(promotionCode), X=∅ to enumerate only
+   * maximal cliques containing the code.
+   *
+   * Notes:
+   *   - If the code is not present after canonicalization (merge + symmetry), returns an empty result.
+   *   - Result order is not guaranteed; sort externally for deterministic comparisons.
+   *
+   * @param promotionCode the code of the promotion to include
+   * @param allPromotions all available promotions (duplicates by code are allowed)
+   * @return all maximal PromotionCombos containing the given code (order not guaranteed)
    */
   def combinablePromotions(
     promotionCode: String,
     allPromotions: Seq[Promotion]
   ): Seq[PromotionCombo] =
-    if allPromotions.exists(_.code == promotionCode) then
-      val validCombosWithCode = generateValidCombinationsContaining(promotionCode, allPromotions)
-      findMaximalCombinations(validCombosWithCode, allPromotions)
-    else Seq.empty
-
-  /**
-   * Generate all valid combinations
-   */
-  private def generateAllValidCombinations(allPromotions: Seq[Promotion]): Seq[PromotionCombo] =
-    val codes = allPromotions.map(_.code)
     val promotionMap = buildPromotionMap(allPromotions)
-
-    for
-      size        <- 1 to codes.length
-      combination <- codes.combinations(size)
-      if isValidCombination(combination, promotionMap)
-    yield PromotionCombo(combination)
-
-  /**
-   * Generate all valid combinations containing the target code
-   */
-  private def generateValidCombinationsContaining(
-    targetCode: String,
-    allPromotions: Seq[Promotion]
-  ): Seq[PromotionCombo] =
-    val otherCodes = allPromotions.map(_.code).filterNot(_ == targetCode)
-    val promotionMap = buildPromotionMap(allPromotions)
-
-    for
-      size        <- 0 to otherCodes.length
-      combination <- otherCodes.combinations(size)
-      fullCombo = targetCode +: combination
-      if isValidCombination(fullCombo, promotionMap)
-    yield PromotionCombo(fullCombo)
+    if !promotionMap.contains(promotionCode) then Seq.empty
+    else
+      val compatibilityGraph = buildCompatibilityGraph(promotionMap)
+      val r = Set(promotionCode)
+      val p = compatibilityGraph.getOrElse(promotionCode, Set.empty)
+      val x = Set.empty[String]
+      val cliques = bronKerboschPivot(r, p, x, compatibilityGraph)
+      cliques.map(c => PromotionCombo(c.toSeq)).toSeq
 
   /**
-   * Pick the maximal from valid combinations list.
-   */
-  private def findMaximalCombinations(
-    validCombos: Seq[PromotionCombo],
-    allPromotions: Seq[Promotion]
-  ): Seq[PromotionCombo] =
-    val allCodes = allPromotions.map(_.code)
-    val promotionMap = buildPromotionMap(allPromotions)
-
-    validCombos.filter: combo =>
-      val unusedCodes = allCodes.filterNot(combo.promotionCodes.contains)
-      unusedCodes.forall: newCode =>
-        val extendedCombo = combo.promotionCodes :+ newCode
-        !isValidCombination(extendedCombo, promotionMap)
-
-  /**
-   * Validate whether a given set of promotion codes forms a combinable group.
-   */
-  private def isValidCombination(
-    codes: Seq[String],
-    promotionMap: Map[String, Set[String]]
-  ): Boolean =
-    codes.forall: code =>
-      val incompatibleCodes = promotionMap.getOrElse(code, Set.empty)
-      val otherCodes = codes.filterNot(_ == code)
-      otherCodes.forall(!incompatibleCodes.contains(_))
-
-  /**
-   * Build a lookup map where each promotion code is associated with the list of codes it cannot be combined with. This
-   * precomputation avoids repeatedly scanning the full list of promotions during validation.
+   * Build a canonical lookup map code -> incompatible codes.
+   *
+   *   - Duplicates by code are merged by unioning their `notCombinableWith` sets.
+   *   - Incompatibilities are symmetrized so the relation can be treated as undirected.
+   *   - Complexity: O(n + m), where n is number of codes and m the number of declared incompatibilities.
+   *   - Output map does not guarantee key order; sort keys externally if a stable order is needed.
+   *
+   * This precomputation avoids repeatedly scanning the full list of promotions during validation.
    */
   private def buildPromotionMap(allPromotions: Seq[Promotion]): Map[String, Set[String]] =
-    allPromotions.groupMapReduce(_.code)(_.notCombinableWith.toSet)(_ ++ _)
+    val merged: Map[String, Set[String]] =
+      allPromotions.groupMapReduce(_.code)(_.notCombinableWith.toSet)(_ ++ _)
+    val withSymmetry: Map[String, Set[String]] =
+      merged.foldLeft(merged) { case (acc, (code, notWith)) =>
+        notWith.foldLeft(acc) { (innerAcc, other) =>
+          val existing = innerAcc.getOrElse(other, Set.empty)
+          innerAcc.updated(other, existing + code)
+        }
+      }
+    withSymmetry
+
+  /**
+   * Build the undirected compatibility graph from the incompatibility map. Two codes are compatible iff neither lists
+   * the other as incompatible.
+   *
+   * Complexity: worst-case O(n&#94;2) to consider all pairs; typically less if neighbor sets are sparse.
+   */
+  private def buildCompatibilityGraph(promotionMap: Map[String, Set[String]]): Map[String, Set[String]] =
+    val codes = promotionMap.keySet
+    codes
+      .map: a =>
+        val neighbors = codes - a filter: b =>
+          val aIncompat = promotionMap.getOrElse(a, Set.empty)
+          val bIncompat = promotionMap.getOrElse(b, Set.empty)
+          !aIncompat.contains(b) && !bIncompat.contains(a)
+        a -> neighbors
+      .toMap
+
+  /**
+   * Bron–Kerbosch algorithm with pivoting to enumerate all maximal cliques. R: current clique, P: prospective vertices
+   * to expand, X: already processed (to avoid duplicates).
+   */
+  private def bronKerboschPivot(
+    r: Set[String],
+    p: Set[String],
+    x: Set[String],
+    graph: Map[String, Set[String]]
+  ): Set[Set[String]] =
+    if p.isEmpty && x.isEmpty then Set(r)
+    else
+      // Choose a pivot u from P ∪ X to reduce branching; iterate over P \ N(u)
+      val px = p union x
+      val u = px.headOption.getOrElse("")
+      val nOfU = graph.getOrElse(u, Set.empty)
+      val candidates = p diff nOfU
+      candidates
+        .foldLeft((Set.empty[Set[String]], p, x)) { case ((acc, pAcc, xAcc), v) =>
+          val nOfV = graph.getOrElse(v, Set.empty)
+          val nextR = r + v
+          val nextP = pAcc intersect nOfV
+          val nextX = xAcc intersect nOfV
+          val found = bronKerboschPivot(nextR, nextP, nextX, graph)
+          (acc union found, pAcc - v, xAcc + v)
+        }
+        ._1

--- a/src/test/scala/dev/gaston/schabas/take/home/zyzygy/problem2/Problem2SolutionTest.scala
+++ b/src/test/scala/dev/gaston/schabas/take/home/zyzygy/problem2/Problem2SolutionTest.scala
@@ -111,3 +111,39 @@ class Problem2SolutionTest extends AnyFunSuite with Matchers:
     val result = Problem2Solution.combinablePromotions("P99", samplePromotions)
     result should be(empty)
   }
+
+  test("allCombinablePromotions should return the single promotion when only one exists") {
+    val single = Seq(Promotion("P1", Seq.empty))
+    val expected = Seq(PromotionCombo(Seq("P1")))
+    val result = Problem2Solution.allCombinablePromotions(single)
+    result.map(_.withSortedCodes) should contain theSameElementsAs expected.map(_.withSortedCodes)
+  }
+
+  test("allCombinablePromotions should return one combo with all when all are mutually compatible") {
+    val promos = Seq(
+      Promotion("P1", Seq.empty),
+      Promotion("P2", Seq.empty),
+      Promotion("P3", Seq.empty)
+    )
+
+    val expected = Seq(PromotionCombo(Seq("P1", "P2", "P3")))
+    val result = Problem2Solution.allCombinablePromotions(promos)
+    result.map(_.withSortedCodes) should contain theSameElementsAs expected.map(_.withSortedCodes)
+  }
+
+  test("allCombinablePromotions should ignore duplicated promotions by code") {
+    val promos = Seq(
+      Promotion("P1", Seq("P2")),
+      Promotion("P1", Seq("P3")),
+      Promotion("P2", Seq("P1")),
+      Promotion("P3", Seq.empty)
+    )
+
+    val expected = Seq(
+      PromotionCombo(Seq("P1")),
+      PromotionCombo(Seq("P2", "P3"))
+    )
+
+    val result = Problem2Solution.allCombinablePromotions(promos)
+    result.map(_.withSortedCodes) should contain theSameElementsAs expected.map(_.withSortedCodes)
+  }


### PR DESCRIPTION
- Replaced previous brute-force subset enumeration + validity filtering + maximal filtering with the Bron–Kerbosch algorithm (with pivoting) to enumerate maximal combinable sets more efficiently.
- Added more edge-case tests for Problem 2.
- Removed unused methods